### PR TITLE
add constraint for delete requests

### DIFF
--- a/base/delete-annotation-requirement.yaml
+++ b/base/delete-annotation-requirement.yaml
@@ -1,0 +1,165 @@
+# blocks deletion of an object unless it is annotated with '$input.parameters.name: $input.parameters.value'
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: deleteannotationrequirement
+spec:
+  crd:
+    spec:
+      names:
+        kind: DeleteAnnotationRequirement
+        listKind: DeleteAnnotationRequirementList
+        plural: deleteannotationrequirements
+        singular: deleteannotationrequirement
+      validation:
+        openAPIV3Schema:
+          required: [name, value]
+          properties:
+            name:
+              type: string
+            value:
+              type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package deleteannotationrequirement
+
+        violation[{"msg": msg, "details": {
+            "name": name,
+            "kind": kind,
+            "namespace": namespace
+        }}] {
+          name := input.review.object.metadata.name
+          kind := input.review.kind.kind
+          namespace := input.review.namespace
+
+          input.review.operation == "DELETE"
+          not input.review.object.metadata.annotations[input.parameters.name] == input.parameters.value
+
+          msg := sprintf("the %v '%v' must be annotated with '%v: \"%v\"' to be deleted", [kind, name, input.parameters.name, input.parameters.value])
+        }
+
+        # test that an object annotated with "true" is allowed
+        test_annotated_allowed {
+            not violation[{
+                "msg": "",
+                "details": {
+                    "name": "example-ns",
+                    "kind": "Namespace",
+                    "namespace": "example-ns"
+                }
+            }] with input as {
+                "review": {
+                    "namespace": "example-ns",
+                    "kind": {
+                        "kind": "Namespace"
+                    },
+                    "object": {
+                        "metadata": {
+                            "name": "example-ns",
+                            "annotations": {
+                              "example.com/delete-allowed": "true"
+                            }
+                        }
+                    },
+                    "operation": "DELETE"
+                },
+                "parameters": {
+                    "name": "example.com/delete-allowed",
+                    "value": "true",
+                }
+            }
+        }
+
+        # test that an object annotated with "false" is denied
+        test_annotated_denied {
+            violation[{
+                "msg": "the Namespace 'example-ns' must be annotated with 'example.com/delete-allowed: \"true\"' to be deleted",
+                "details": {
+                    "name": "example-ns",
+                    "kind": "Namespace",
+                    "namespace": "example-ns"
+                }
+            }] with input as {
+                "review": {
+                    "namespace": "example-ns",
+                    "kind": {
+                        "kind": "Namespace"
+                    },
+                    "object": {
+                        "metadata": {
+                            "name": "example-ns",
+                            "annotations": {
+                              "example.com/delete-allowed": "false"
+                            }
+                        }
+                    },
+                    "operation": "DELETE"
+                },
+                "parameters": {
+                    "name": "example.com/delete-allowed",
+                    "value": "true"
+                }
+            }
+        }
+
+        # test that an object without any annotation at all is denied
+        test_not_annotated_denied {
+            violation[{
+                "msg": "the Namespace 'example-ns' must be annotated with 'example.com/delete-allowed: \"true\"' to be deleted",
+                "details": {
+                    "name": "example-ns",
+                    "kind": "Namespace",
+                    "namespace": "example-ns"
+                }
+            }] with input as {
+                "review": {
+                    "namespace": "example-ns",
+                    "kind": {
+                        "kind": "Namespace"
+                    },
+                    "object": {
+                        "metadata": {
+                            "name": "example-ns"
+                        }
+                    },
+                    "operation": "DELETE"
+                },
+                "parameters": {
+                    "name": "example.com/delete-allowed",
+                    "value": "true",
+                }
+            }
+        }
+
+        # test that the policy only applies to delete operations
+        test_create_allowed {
+            not violation[{
+                "msg": "",
+                "details": {
+                    "name": "example-ns",
+                    "kind": "Namespace",
+                    "namespace": "example-ns"
+                }
+            }] with input as {
+                "review": {
+                    "namespace": "example-ns",
+                    "kind": {
+                        "kind": "Namespace"
+                    },
+                    "object": {
+                        "metadata": {
+                            "name": "example-ns",
+                            "annotations": {
+                              "example.com/delete-allowed": "false"
+                            }
+                        }
+                    },
+                    "operation": "CREATE"
+                },
+                "parameters": {
+                    "name": "example.com/delete-allowed",
+                    "value": "true",
+                }
+            }
+        }

--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - delete-annotation-requirement.yaml
   - ingress-host-restriction.yaml
   - name-label-match.yaml

--- a/example/delete-namespace-annotation.yaml
+++ b/example/delete-namespace-annotation.yaml
@@ -1,0 +1,13 @@
+# block namespace delete requests unless the namespace is annotated with example.com/delete-allowed: "true"
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: DeleteAnnotationRequirement
+metadata:
+  name: namespace
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Namespace"]
+  parameters:
+    name: "example.com/delete-allowed"
+    value: "true"

--- a/example/kustomization.yaml
+++ b/example/kustomization.yaml
@@ -4,5 +4,6 @@ bases:
   - ../base
   #  - github.com/utilitywarehouse/gatekeeper-template-manifests/base?ref=1.0.0
 resources:
+  - delete-namespace-annotation.yaml
   - ingress-host-restriction.yaml
   - namespace-name-label-match.yaml


### PR DESCRIPTION
This constraint template blocks delete requests for objects unless they are annotated with a specified key and value combination. The types of objects that this policy applies to are controlled by the definition of the constraint (see the example).