### PR TITLE
rework IngressHostRestriction to also include paths in the whitelist

### DIFF
--- a/base/library/ingress-host-restriction/src.rego
+++ b/base/library/ingress-host-restriction/src.rego
@@ -1,22 +1,36 @@
 package ingresshostrestriction
 
-violation[{"msg": msg, "details": {"host": host, "namespace": namespace}}] {
-    host := input.review.object.spec.rules[_].host
+violation[{"msg": msg, "details": {"host": host, "namespace": namespace, "paths": paths}}] {
+    name := input.review.object.metadata.name
     namespace := input.review.namespace
-    allowed_namespaces := input.parameters.namespaces
+    host := input.review.object.spec.rules[i].host
+    paths := {x | x = input.review.object.spec.rules[i]["http"]["paths"][_].path}
+    whitelist := input.parameters.namespacePathWhitelist
 
     # resource kind is Ingress
-    input.review.kind.kind == "Ingress" 
+    input.review.kind.kind == "Ingress"
 
-    # ingress host matches blacklisted host
-    host == input.parameters.host 
+    # operation is CREATE or UPDATE
+    operations = {"CREATE", "UPDATE"}
+    operations[input.review.operation]
+
+    # ingress host matches the restricted host
+    host == input.parameters.host
     
-    # namespace is not in the list of allowed namespaces
-    not allowed(allowed_namespaces, namespace) 
+    # namespace+host+path(s) is not in the list of allowed namespaces+paths
+    not allowed(whitelist, namespace, paths)
 
-    msg := sprintf("%v is not a permitted host value for ingresses in this namespace (%v)", [host, namespace])
+    msg := sprintf("Ingress '%v' denied; the host and/or path values are not permitted for this namespace host=%v namespace=%v paths=%v", [name, host, namespace, paths])
 }
 
-allowed(allowed_namespaces, namespace) {
-    allowed_namespaces[_] == namespace
+allowed(whitelist, namespace, paths) {
+    # check that this namespace has whitelisted paths
+    count(whitelist[namespace]) > 0
+
+    # find the intersection of the whitelisted paths for this host/namespace and the paths defined in the ingress rule
+    whitelisted_paths := {x | x = whitelist[namespace][_]}
+    test := paths & whitelisted_paths
+
+    # all the paths should intersect with the list of allowed paths
+    count(test) == count(paths)
 }

--- a/base/library/ingress-host-restriction/src.rego
+++ b/base/library/ingress-host-restriction/src.rego
@@ -27,10 +27,8 @@ allowed(whitelist, namespace, paths) {
     # check that this namespace has whitelisted paths
     count(whitelist[namespace]) > 0
 
-    # find the intersection of the whitelisted paths for this host/namespace and the paths defined in the ingress rule
+    # all the paths should be in the list of whitelisted paths for this namespace
     whitelisted_paths := {x | x = whitelist[namespace][_]}
-    test := paths & whitelisted_paths
-
-    # all the paths should intersect with the list of allowed paths
-    count(test) == count(paths)
+    paths_in_whitelist := paths & whitelisted_paths
+    count(paths_in_whitelist) == count(paths)
 }

--- a/base/library/ingress-host-restriction/src_test.rego
+++ b/base/library/ingress-host-restriction/src_test.rego
@@ -1,95 +1,932 @@
 package ingresshostrestriction
 
-test_matching_host_denied {
-    violation[{
-        "msg": "example.com is not a permitted host value for ingresses in this namespace (example-ns)",
-        "details": {
-            "host": "example.com",
-            "namespace": "example-ns"
-        }
-    }] with input as {
+# test the simplest case: all values in the resource are in the whitelist
+test_matching_host_matching_namespace_matching_path_allowed {
+    results := violation with input as {
         "parameters": {
-            "namespaces": [],
+            "namespacePathWhitelist":
+                {
+                    "example-ns": [
+                        "/",
+                    ]
+                },
             "host": "example.com"
         },
         "review": {
+            "operation": "CREATE",
             "namespace": "example-ns",
             "kind": {
                 "kind": "Ingress"
             },
             "object": {
+                "metadata": {
+                    "name": "test"
+                },
                 "spec": {
                     "rules": [
                         {
-                            "host": "example.com"
+                            "host": "example.com",
+                            "http": {
+                                "paths": [
+                                    {
+                                        "path": "/"
+                                    }
+                                ]
+                            }
                         }
                     ]
                 }
             }
         }
     }
+    count(results) == 0
 }
 
-test_different_host_allowed {
-    not violation[{
-        "msg": "", 
-        "details": {
-            "host": "",
-            "namespace": ""
-        }
-    }] with input as {
+# test a path that isn't in the whitelist
+test_matching_host_matching_namespace_different_path_denied {
+    results := violation with input as {
         "parameters": {
-            "namespaces": [
-                "different-example-ns"
-            ],
-            "host": "example.com"
-        },
-        "review": {
-            "namespace": "example-ns",
-            "kind": {
-                "kind": "Ingress"
-            },
-            "object": {
-                "spec": {
-                    "rules": [
-                        {
-                            "host": "different.example.com"
-                        }
+            "namespacePathWhitelist":
+                {
+                    "example-ns": [
+                        "/",
                     ]
-                }
-            }
-        }
-    }   
-}
-
-test_matching_namespace_allowed {
-    not violation[{
-        "msg": "",
-        "details": {
-            "host": "",
-            "namespace": ""
-        }
-    }] with input as {
-        "parameters": {
-            "namespaces": [
-                "example-ns"
-            ],
+                },
             "host": "example.com"
         },
         "review": {
+            "operation": "CREATE",
             "namespace": "example-ns",
             "kind": {
                 "kind": "Ingress"
             },
             "object": {
+                "metadata": {
+                    "name": "test"
+                },
                 "spec": {
                     "rules": [
                         {
-                            "host": "example.com"
+                            "host": "example.com",
+                            "http": {
+                                "paths": [
+                                    {
+                                        "path": "/disallowed"
+                                    }
+                                ]
+                            }
                         }
                     ]
                 }
             }
         }
     }
+    count(results) > 0
+}
+
+# test a host and path combination in a namespace that isn't whitelisted
+test_matching_host_different_namespace_matching_path_denied {
+    results := violation with input as {
+        "parameters": {
+            "namespacePathWhitelist":
+                {
+                    "example-ns": [
+                        "/",
+                    ]
+                },
+            "host": "example.com"
+        },
+        "review": {
+            "operation": "CREATE",
+            "namespace": "different-example-ns",
+            "kind": {
+                "kind": "Ingress"
+            },
+            "object": {
+                "metadata": {
+                    "name": "test"
+                },
+                "spec": {
+                    "rules": [
+                        {
+                            "host": "example.com",
+                            "http": {
+                                "paths": [
+                                    {
+                                        "path": "/"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    }
+    count(results) > 0
+}
+
+# test an ingress request for the right host where the neither the namespace or path are whitelisted
+test_matching_host_different_namespace_different_path_denied {
+    results := violation with input as {
+        "parameters": {
+            "namespacePathWhitelist":
+                {
+                    "example-ns": [
+                        "/",
+                    ]
+                },
+            "host": "example.com"
+        },
+        "review": {
+            "operation": "CREATE",
+            "namespace": "different-example-ns",
+            "kind": {
+                "kind": "Ingress"
+            },
+            "object": {
+                "metadata": {
+                    "name": "test"
+                },
+                "spec": {
+                    "rules": [
+                        {
+                            "host": "example.com",
+                            "http": {
+                                "paths": [
+                                    {
+                                        "path": "/disallowed"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    }
+    count(results) > 0
+}
+
+# test that a different host is ignored by the constraint, regardless of a matching namespace/path
+test_different_host_matching_namespace_matching_path_allowed {
+    results := violation with input as {
+        "parameters": {
+            "namespacePathWhitelist":
+                {
+                    "example-ns": [
+                        "/",
+                    ]
+                },
+            "host": "example.com"
+        },
+        "review": {
+            "operation": "CREATE",
+            "namespace": "example-ns",
+            "kind": {
+                "kind": "Ingress"
+            },
+            "object": {
+                "metadata": {
+                    "name": "test"
+                },
+                "spec": {
+                    "rules": [
+                        {
+                            "host": "different.example.com",
+                            "http": {
+                                "paths": [
+                                    {
+                                        "path": "/"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    }
+    count(results) == 0
+}
+
+# test that a different host is ignored by the constraint, regardless of a matching namespace
+test_different_host_matching_namespace_different_path_allowed {
+    results := violation with input as {
+        "parameters": {
+            "namespacePathWhitelist":
+                {
+                    "example-ns": [
+                        "/",
+                    ]
+                },
+            "host": "example.com"
+        },
+        "review": {
+            "operation": "CREATE",
+            "namespace": "example-ns",
+            "kind": {
+                "kind": "Ingress"
+            },
+            "object": {
+                "metadata": {
+                    "name": "test"
+                },
+                "spec": {
+                    "rules": [
+                        {
+                            "host": "different.example.com",
+                            "http": {
+                                "paths": [
+                                    {
+                                        "path": "/disallowed"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    }
+    count(results) == 0
+}
+
+# test that a different host is ignored by the constraint, regardless of a matching path
+test_different_host_different_namespace_matching_path_allowed {
+    results := violation with input as {
+        "request": {
+            "operation": "CREATE"
+        },
+        "parameters": {
+            "namespacePathWhitelist":
+                {
+                    "example-ns": [
+                        "/",
+                    ]
+                },
+            "host": "example.com"
+        },
+        "review": {
+            "namespace": "different-example-ns",
+            "kind": {
+                "kind": "Ingress"
+            },
+            "object": {
+                "metadata": {
+                    "name": "test"
+                },
+                "spec": {
+                    "rules": [
+                        {
+                            "host": "different.example.com",
+                            "http": {
+                                "paths": [
+                                    {
+                                        "path": "/"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    }
+    count(results) == 0
+}
+
+# test that a completely unrelated ingress is ignored by the constraint
+test_different_host_different_namespace_different_path_allowed {
+    results := violation with input as {
+        "parameters": {
+            "namespacePathWhitelist":
+                {
+                    "example-ns": [
+                        "/",
+                    ]
+                },
+            "host": "example.com"
+        },
+        "review": {
+            "operation": "CREATE",
+            "namespace": "different-example-ns",
+            "kind": {
+                "kind": "Ingress"
+            },
+            "object": {
+                "metadata": {
+                    "name": "test"
+                },
+                "spec": {
+                    "rules": [
+                        {
+                            "host": "different.example.com",
+                            "http": {
+                                "paths": [
+                                    {
+                                        "path": "/different"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    }
+    count(results) == 0
+}
+
+# test that an ingress with a matching host/path combination but another unrelated rule is allowed
+test_multiple_host_host_matching_path_matching_allowed {
+    results := violation with input as {
+        "parameters": {
+            "namespacePathWhitelist":
+                {
+                    "example-ns": [
+                        "/",
+                    ]
+                },
+            "host": "example.com"
+        },
+        "review": {
+            "operation": "CREATE",
+            "namespace": "example-ns",
+            "kind": {
+                "kind": "Ingress"
+            },
+            "object": {
+                "metadata": {
+                    "name": "test"
+                },
+                "spec": {
+                    "rules": [
+                        {
+                            "host": "different.example.com",
+                            "http": {
+                                "paths": [
+                                    {
+                                        "path": "/"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "host": "example.com",
+                            "http": {
+                                "paths": [
+                                    {
+                                        "path": "/"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    }
+    count(results) == 0
+}
+
+# test that an invalid rule is still denied even when there is another unrelated rule
+test_multiple_host_host_matching_path_different_denied {
+    results := violation with input as {
+        "parameters": {
+            "namespacePathWhitelist":
+                {
+                    "example-ns": [
+                        "/",
+                    ]
+                },
+            "host": "example.com"
+        },
+        "review": {
+            "operation": "CREATE",
+            "namespace": "example-ns",
+            "kind": {
+                "kind": "Ingress"
+            },
+            "object": {
+                "metadata": {
+                    "name": "test"
+                },
+                "spec": {
+                    "rules": [
+                        {
+                            "host": "different.example.com",
+                            "http": {
+                                "paths": [
+                                    {
+                                        "path": "/"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "host": "example.com",
+                            "http": {
+                                "paths": [
+                                    {
+                                        "path": "/different"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    }
+    count(results) > 0
+}
+
+# test that an invalid rule is still denied even when there is another unrelated rule
+test_multiple_host_host_different_path_matching_allowed {
+    results := violation with input as {
+        "parameters": {
+            "namespacePathWhitelist":
+                {
+                    "example-ns": [
+                        "/",
+                    ]
+                },
+            "host": "example.com"
+        },
+        "review": {
+            "operation": "CREATE",
+            "namespace": "example-ns",
+            "kind": {
+                "kind": "Ingress"
+            },
+            "object": {
+                "metadata": {
+                    "name": "test"
+                },
+                "spec": {
+                    "rules": [
+                        {
+                            "host": "different.example.com",
+                            "http": {
+                                "paths": [
+                                    {
+                                        "path": "/"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "host": "different-2.example.com",
+                            "http": {
+                                "paths": [
+                                    {
+                                        "path": "/"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    }
+    count(results) == 0
+}
+
+# test multiple whitelisted paths are allowed
+test_multiple_paths_all_matching_allowed {
+    results := violation with input as {
+        "request": {
+            "operation": "CREATE"
+        },
+        "parameters": {
+            "namespacePathWhitelist":
+                {
+                    "example-ns": [
+                        "/",
+                        "/example"
+                    ]
+                },
+            "host": "example.com"
+        },
+        "review": {
+            "operation": "CREATE",
+            "namespace": "example-ns",
+            "kind": {
+                "kind": "Ingress"
+            },
+            "object": {
+                "metadata": {
+                    "name": "test"
+                },
+                "spec": {
+                    "rules": [
+                        {
+                            "host": "example.com",
+                            "http": {
+                                "paths": [
+                                    {
+                                        "path": "/"
+                                    },
+                                    {
+                                        "path": "/example"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    }
+    count(results) == 0
+}
+
+# test that one bad path results in denial
+test_multiple_paths_one_different_denied {
+    results := violation with input as {
+        "parameters": {
+            "namespacePathWhitelist":
+                {
+                    "example-ns": [
+                        "/",
+                        "/example"
+                    ]
+                },
+            "host": "example.com"
+        },
+        "review": {
+            "operation": "CREATE",
+            "namespace": "example-ns",
+            "kind": {
+                "kind": "Ingress"
+            },
+            "object": {
+                "metadata": {
+                    "name": "test"
+                },
+                "spec": {
+
+                    "rules": [
+                        {
+                            "host": "example.com",
+                            "http": {
+                                "paths": [
+                                    {
+                                        "path": "/"
+                                    },
+                                    {
+                                        "path": "/different"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    }
+    count(results) > 0
+}
+
+# test that the resource is denied when all paths are different
+test_multiple_paths_all_different_denied {
+    results := violation with input as {
+        "parameters": {
+            "namespacePathWhitelist":
+                {
+                    "example-ns": [
+                        "/",
+                        "/example"
+                    ]
+                },
+            "host": "example.com"
+        },
+        "review": {
+            "operation": "CREATE",
+            "namespace": "example-ns",
+            "kind": {
+                "kind": "Ingress"
+            },
+            "object": {
+                "metadata": {
+                    "name": "test"
+                },
+                "spec": {
+                    "rules": [
+                        {
+                            "host": "example.com",
+                            "http": {
+                                "paths": [
+                                    {
+                                        "path": "/different"
+                                    },
+                                    {
+                                        "path": "/another-different"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    }
+    count(results) > 0
+}
+
+# test that an ingress is allowed, even if it doesn't define ALL of the paths that are whitelisted
+test_multiple_paths_more_whitelisted_allowed {
+    results := violation with input as {
+        "parameters": {
+            "namespacePathWhitelist":
+                {
+                    "example-ns": [
+                        "/",
+                        "/example",
+                        "/example2",
+                        "/example3",
+                        "/example4"
+                    ]
+                },
+            "host": "example.com"
+        },
+        "review": {
+            "operation": "CREATE",
+            "namespace": "example-ns",
+            "kind": {
+                "kind": "Ingress"
+            },
+            "object": {
+                "metadata": {
+                    "name": "test"
+                },
+                "spec": {
+                    "rules": [
+                        {
+                            "host": "example.com",
+                            "http": {
+                                "paths": [
+                                    {
+                                        "path": "/"
+                                    },
+                                    {
+                                        "path": "/example2"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    }
+    count(results) == 0
+}
+
+# test that an ingress is denied if the ingresshostrestriction doesn't have any paths against the namespace
+test_no_whitelisted_paths_denied {
+    results := violation with input as {
+        "parameters": {
+            "namespacePathWhitelist":
+                {
+                    "example-ns": []
+                },
+            "host": "example.com"
+        },
+        "review": {
+            "operation": "CREATE",
+            "namespace": "example-ns",
+            "kind": {
+                "kind": "Ingress"
+            },
+            "object": {
+                "metadata": {
+                    "name": "test"
+                },
+                "spec": {
+                    "rules": [
+                        {
+                            "host": "example.com",
+                            "http": {
+                                "paths": [
+                                    {
+                                        "path": "/"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    }
+    count(results) > 0
+}
+
+# test that an ingress is denied if the whitelist is defined as a string
+test_namespace_path_list_string_denied {
+    results := violation with input as {
+        "parameters": {
+            "namespacePathWhitelist":
+                {
+                    "example-ns": ""
+                },
+            "host": "example.com"
+        },
+        "review": {
+            "operation": "CREATE",
+            "namespace": "example-ns",
+            "kind": {
+                "kind": "Ingress"
+            },
+            "object": {
+                "metadata": {
+                    "name": "test"
+                },
+                "spec": {
+                    "rules": [
+                        {
+                            "host": "example.com",
+                            "http": {
+                                "paths": [
+                                    {
+                                        "path": "/"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    }
+    count(results) > 0
+}
+
+# test that an ingress is denied if the whitelist is defined as an object
+test_namespace_path_list_object_denied {
+    results := violation with input as {
+        "parameters": {
+            "namespacePathWhitelist":
+                {
+                    "example-ns": {}
+                },
+            "host": "example.com"
+        },
+        "review": {
+            "operation": "CREATE",
+            "namespace": "example-ns",
+            "kind": {
+                "kind": "Ingress"
+            },
+            "object": {
+                "metadata": {
+                    "name": "test"
+                },
+                "spec": {
+                    "rules": [
+                        {
+                            "host": "example.com",
+                            "http": {
+                                "paths": [
+                                    {
+                                        "path": "/"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    }
+    count(results) > 0
+}
+
+# test that a delete request is allowed, even when the resource violates the constraint
+test_delete_request_allowed {
+    results := violation with input as {
+        "parameters": {
+            "namespacePathWhitelist":
+                {
+                    "example-ns": [
+                        "/"
+                    ]
+                },
+            "host": "example.com"
+        },
+        "review": {
+            "operation": "DELETE",
+            "namespace": "example-ns",
+            "kind": {
+                "kind": "Ingress"
+            },
+            "object": {
+                "metadata": {
+                    "name": "test"
+                },
+                "spec": {
+                    "rules": [
+                        {
+                            "host": "example.com",
+                            "http": {
+                                "paths": [
+                                    {
+                                        "path": "/different"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    }
+    count(results) == 0
+}
+
+# test that a violating update request is denied
+test_update_request_denied {
+    results := violation with input as {
+        "parameters": {
+            "namespacePathWhitelist":
+                {
+                    "example-ns": [
+                        "/"
+                    ]
+                },
+            "host": "example.com"
+        },
+        "review": {
+            "operation": "UPDATE",
+            "namespace": "example-ns",
+            "kind": {
+                "kind": "Ingress"
+            },
+            "object": {
+                "metadata": {
+                    "name": "test"
+                },
+                "spec": {
+                    "rules": [
+                        {
+                            "host": "example.com",
+                            "http": {
+                                "paths": [
+                                    {
+                                        "path": "/different"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    }
+    count(results) > 0
+}
+
+# test that a valid update request is denied
+test_update_request_allowed {
+    results := violation with input as {
+        "parameters": {
+            "namespacePathWhitelist":
+                {
+                    "example-ns": [
+                        "/"
+                    ]
+                },
+            "host": "example.com"
+        },
+        "review": {
+            "operation": "UPDATE",
+            "namespace": "example-ns",
+            "kind": {
+                "kind": "Ingress"
+            },
+            "object": {
+                "metadata": {
+                    "name": "test"
+                },
+                "spec": {
+                    "rules": [
+                        {
+                            "host": "example.com",
+                            "http": {
+                                "paths": [
+                                    {
+                                        "path": "/"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    }
+    count(results) == 0
 }

--- a/base/library/ingress-host-restriction/template.yaml
+++ b/base/library/ingress-host-restriction/template.yaml
@@ -13,35 +13,48 @@ spec:
         singular: ingresshostrestriction
       validation:
         openAPIV3Schema:
-          required: [host, namespaces]
+          required: [host, namespacePathWhitelist]
           properties:
             host:
               type: string
-            namespaces:
-              type: array
-              items: string
+            namespacePathWhitelist:
+              type: object
   targets:
     - target: admission.k8s.gatekeeper.sh
       rego: |
         package ingresshostrestriction
 
-        violation[{"msg": msg, "details": {"host": host, "namespace": namespace}}] {
-            host := input.review.object.spec.rules[_].host
+        violation[{"msg": msg, "details": {"host": host, "namespace": namespace, "paths": paths}}] {
+            name := input.review.object.metadata.name
             namespace := input.review.namespace
-            allowed_namespaces := input.parameters.namespaces
+            host := input.review.object.spec.rules[i].host
+            paths := {x | x = input.review.object.spec.rules[i]["http"]["paths"][_].path}
+            whitelist := input.parameters.namespacePathWhitelist
 
             # resource kind is Ingress
-            input.review.kind.kind == "Ingress" 
+            input.review.kind.kind == "Ingress"
 
-            # ingress host matches blacklisted host
-            host == input.parameters.host 
+            # operation is CREATE or UPDATE
+            operations = {"CREATE", "UPDATE"}
+            operations[input.review.operation]
+
+            # ingress host matches the restricted host
+            host == input.parameters.host
             
-            # namespace is not in the list of allowed namespaces
-            not allowed(allowed_namespaces, namespace) 
+            # namespace+host+path(s) is not in the list of allowed namespaces+paths
+            not allowed(whitelist, namespace, paths)
 
-            msg := sprintf("%v is not a permitted host value for ingresses in this namespace (%v)", [host, namespace])
+            msg := sprintf("Ingress '%v' denied; the host and/or path values are not permitted for this namespace host=%v namespace=%v paths=%v", [name, host, namespace, paths])
         }
 
-        allowed(allowed_namespaces, namespace) {
-            allowed_namespaces[_] == namespace
+        allowed(whitelist, namespace, paths) {
+            # check that this namespace has whitelisted paths
+            count(whitelist[namespace]) > 0
+
+            # find the intersection of the whitelisted paths for this host/namespace and the paths defined in the ingress rule
+            whitelisted_paths := {x | x = whitelist[namespace][_]}
+            test := paths & whitelisted_paths
+
+            # all the paths should intersect with the list of allowed paths
+            count(test) == count(paths)
         }

--- a/base/library/ingress-host-restriction/template.yaml
+++ b/base/library/ingress-host-restriction/template.yaml
@@ -51,10 +51,8 @@ spec:
             # check that this namespace has whitelisted paths
             count(whitelist[namespace]) > 0
 
-            # find the intersection of the whitelisted paths for this host/namespace and the paths defined in the ingress rule
+            # all the paths should be in the list of whitelisted paths for this namespace
             whitelisted_paths := {x | x = whitelist[namespace][_]}
-            test := paths & whitelisted_paths
-
-            # all the paths should intersect with the list of allowed paths
-            count(test) == count(paths)
+            paths_in_whitelist := paths & whitelisted_paths
+            count(paths_in_whitelist) == count(paths)
         }

--- a/example/ingress-host-restriction.yaml
+++ b/example/ingress-host-restriction.yaml
@@ -1,4 +1,5 @@
-# restrict example.com as a host value for ingresses to two namespaces: example-ns and example-ns-two
+# restrict example.com as a host value for ingresses to two namespaces: example-ns and example-ns-two,
+# on a different set of paths
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: IngressHostRestriction
 metadata:
@@ -10,6 +11,9 @@ spec:
         kinds: ["Ingress"]
   parameters:
     host: "example.com"
-    namespaces:
-      - example-ns
-      - example-ns-two
+    namespacePathWhitelist:
+      example-ns:
+        - /example
+      example-ns-1:
+        - /metrics
+        - /app/example


### PR DESCRIPTION
Restrict hosts based on the combination of namespace+path(s):
```
apiVersion: constraints.gatekeeper.sh/v1beta1
kind: IngressHostRestriction
metadata:
  name: example-com
spec:
  match:
    kinds:
      - apiGroups: ["extensions"]
        kinds: ["Ingress"]
  parameters:
    host: "example.com"
    namespacePathWhitelist:
      ns-1:
        - /example
      ns-2:
        - /example-1
        - /example-2/example
```