### PR TITLE
remove kind and namespace parameters from namelabelmatch to support CREATE requests

### DIFF
--- a/base/library/name-label-match/src.rego
+++ b/base/library/name-label-match/src.rego
@@ -3,13 +3,9 @@ package namelabelmatch
 violation[{"msg": msg, "details": {
     "label_name": label_name,
     "metadata_name": metadata_name,
-    "kind": kind,
-    "namespace": namespace
 }}] {
     metadata_name := input.review.object.metadata.name
     label_name := input.review.object.metadata.labels.name
-    kind := input.review.kind.kind
-    namespace := input.review.namespace
 
     label_name != metadata_name
 

--- a/base/library/name-label-match/src_test.rego
+++ b/base/library/name-label-match/src_test.rego
@@ -1,20 +1,8 @@
 package namelabelmatch
 
 test_matching_name_allowed {
-    not violation[{
-        "msg": "",
-        "details": {
-            "label_name": "example-ns",
-            "metadata_name": "example-ns",
-            "kind": "Namespace",
-            "namespace": "example-ns"
-        }
-    }] with input as {
+    results := violation with input as {
         "review": {
-            "namespace": "example-ns",
-            "kind": {
-                "kind": "Namespace"
-            },
             "object": {
                 "metadata": {
                     "name": "example-ns",
@@ -25,23 +13,12 @@ test_matching_name_allowed {
             }
         }
     }
+    count(results) == 0
 }
 
 test_not_matching_name_denied {
-    violation[{
-        "msg": "the label 'name' (other-ns) must match the actual name of the object (example-ns)",
-        "details": {
-            "label_name": "other-ns",
-            "metadata_name": "example-ns",
-            "kind": "Namespace",
-            "namespace": "example-ns"
-        }
-    }] with input as {
+    results := violation with input as {
         "review": {
-            "namespace": "example-ns",
-            "kind": {
-                "kind": "Namespace"
-            },
             "object": {
                 "metadata": {
                     "name": "example-ns",
@@ -52,23 +29,12 @@ test_not_matching_name_denied {
             }
         }
     }
+    count(results) > 0
 }
 
 test_no_label_allowed {
-    not violation[{
-        "msg": "the label 'name' () must match the actual name of the object (example-ns)",
-        "details": {
-            "label_name": "",
-            "metadata_name": "example-ns",
-            "kind": "Namespace",
-            "namespace": "example-ns"
-        }
-    }] with input as {
+    results := violation with input as {
         "review": {
-            "namespace": "example-ns",
-            "kind": {
-                "kind": "Namespace"
-            },
             "object": {
                 "metadata": {
                     "name": "example-ns"
@@ -76,4 +42,5 @@ test_no_label_allowed {
             }
         }
     }
+    count(results) == 0
 }

--- a/base/library/name-label-match/template.yaml
+++ b/base/library/name-label-match/template.yaml
@@ -19,13 +19,9 @@ spec:
         violation[{"msg": msg, "details": {
             "label_name": label_name,
             "metadata_name": metadata_name,
-            "kind": kind,
-            "namespace": namespace
         }}] {
             metadata_name := input.review.object.metadata.name
             label_name := input.review.object.metadata.labels.name
-            kind := input.review.kind.kind
-            namespace := input.review.namespace
 
             label_name != metadata_name
 


### PR DESCRIPTION
The `input.review` object doesn't contain the `kind.kind` or `namespace` fields in `CREATE` requests because these details belong to existing resources, whereas `input.review.object` does because this represents the object to be created.

As a result, when we tried to assign `input.review.kind.kind` and `input.review.namespace` to variables in `CREATE` requests, it would evaluate to false before even testing the main condition, meaning this constraint would never produce a violation for a `CREATE` request.

We were only grabbing these values to export them as 'details' and this information is already output by kube when a request is blocked by gatekeeper, so the best thing to do is to just remove them.

With this change, the constraint now works for newly created resources.