### PR TITLE
remove all fields from spec.crd.spec.names, except kind

### DIFF
--- a/base/library/delete-annotation-requirement/template.yaml
+++ b/base/library/delete-annotation-requirement/template.yaml
@@ -8,9 +8,6 @@ spec:
     spec:
       names:
         kind: DeleteAnnotationRequirement
-        listKind: DeleteAnnotationRequirementList
-        plural: deleteannotationrequirements
-        singular: deleteannotationrequirement
       validation:
         openAPIV3Schema:
           required: [name, value]

--- a/base/library/ingress-host-restriction/template.yaml
+++ b/base/library/ingress-host-restriction/template.yaml
@@ -8,9 +8,6 @@ spec:
     spec:
       names:
         kind: IngressHostRestriction
-        listKind: IngressHostRestrictionList
-        plural: ingresshostrestrictions
-        singular: ingresshostrestriction
       validation:
         openAPIV3Schema:
           required: [host, namespacePathWhitelist]

--- a/base/library/name-label-match/template.yaml
+++ b/base/library/name-label-match/template.yaml
@@ -8,9 +8,6 @@ spec:
     spec:
       names:
         kind: NameLabelMatch
-        listKind: NameLabelMatchList
-        plural: namelabelmatches
-        singular: namelabelmatch
   targets:
     - target: admission.k8s.gatekeeper.sh
       rego: |


### PR DESCRIPTION
Despite all the other fields appearing in every example in https://github.com/open-policy-agent/gatekeeper/tree/master/library, only `kind` is actually defined for the CRD.

This has meant that every time the templates are applied the generation is incremented:
```
-  generation: 1891
+  generation: 1892
   name: namelabelmatch
   resourceVersion: "212793173"
   selfLink: /apis/templates.gatekeeper.sh/v1beta1/constrainttemplates/namelabelmatch
@@ -17,6 +17,9 @@
     spec:
       names:
         kind: NameLabelMatch
+        listKind: NameLabelMatchList
+        plural: namelabelmatches
+        singular: namelabelmatch
```

See:
https://github.com/open-policy-agent/gatekeeper/issues/170