### PR TITLE
Use `diff` to check src.rego and template

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,23 @@
+SHELL := /bin/bash
+
+.PHONY: test
 test: opa kustomize template
 
+.PHONY: opa
 opa:
-	@docker run --rm -v $$PWD:/src openpolicyagent/opa test --ignore *.yaml --ignore *.json -v /src/base
+	@docker run --rm -v $$PWD:/src:ro openpolicyagent/opa test --ignore *.yaml --ignore *.json -v /src/base
 
+.PHONY: kustomize
 kustomize:
 	@docker build -t gatekeeper-template-manifests-kustomize -f Dockerfile.kustomize .
 
+.PHONY: template
 template:
-	@docker run --rm -v $$PWD:/workdir mikefarah/yq /bin/sh ./lib/template-match-src/template-match-src.sh
+	@docker run -ti --rm -v $$PWD:/workdir:ro mikefarah/yq /bin/sh -c " \
+		apk --no-cache add bash && \
+		/workdir/lib/template-match-src/template-match-src"
 
+.PHONY: install-git-hooks
 install-git-hooks:
 	@-rm -r .git/hooks
 	@ln -sv ../lib/git-hooks .git/hooks

--- a/lib/template-match-src/template-match-src
+++ b/lib/template-match-src/template-match-src
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # exit 1 for template.yaml files where spec.targets[0].rego doesn't match the
 # contents of src.rego in the same directory
@@ -8,10 +8,13 @@ code=0
 rego_field="spec.targets[0].rego"
 
 while read template_file; do
-	src_file=$(dirname ${template_file})/src.rego
 	IFS=
-	if [[ "$(cat ${src_file})" != "$(yq r "${template_file}" "${rego_field}")" ]]; then
-		echo "${template_file}: the contents of ${rego_field} don't match ${src_file}"
+	src_file=$(dirname ${template_file})/src.rego
+
+	DIFF=$(diff -B <(cat ${src_file})  <(yq r "${template_file}" "${rego_field}"))
+
+	if [[ ${DIFF} != "" ]]; then
+		echo -e "${template_file}: the contents of ${rego_field} don't match ${src_file}:\n\n${DIFF}"
 		code=1
 	fi
 done <<-EOT


### PR DESCRIPTION
Some policies prefer to take out empty lines when copying the src.rego
to a template to improve readability in Kubernetes.

We should allow differences in formatting in our validation.