### PR TITLE
ingresshostrestriction: allow violations for empty operations

### DIFF
--- a/base/library/ingress-host-restriction/src.rego
+++ b/base/library/ingress-host-restriction/src.rego
@@ -10,9 +10,8 @@ violation[{"msg": msg, "details": {"host": host, "namespace": namespace, "paths"
     # resource kind is Ingress
     input.review.kind.kind == "Ingress"
 
-    # operation is CREATE or UPDATE
-    operations = {"CREATE", "UPDATE"}
-    operations[input.review.operation]
+    # always allow deletion of offending ingresses
+    input.review.operation != "DELETE"
 
     # ingress host matches the restricted host
     host == input.parameters.host

--- a/base/library/ingress-host-restriction/src_test.rego
+++ b/base/library/ingress-host-restriction/src_test.rego
@@ -889,7 +889,7 @@ test_update_request_denied {
     count(results) > 0
 }
 
-# test that a valid update request is denied
+# test that a valid update request is allowed
 test_update_request_allowed {
     results := violation with input as {
         "parameters": {
@@ -903,6 +903,90 @@ test_update_request_allowed {
         },
         "review": {
             "operation": "UPDATE",
+            "namespace": "example-ns",
+            "kind": {
+                "kind": "Ingress"
+            },
+            "object": {
+                "metadata": {
+                    "name": "test"
+                },
+                "spec": {
+                    "rules": [
+                        {
+                            "host": "example.com",
+                            "http": {
+                                "paths": [
+                                    {
+                                        "path": "/"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    }
+    count(results) == 0
+}
+
+# test that a violating request with an empty operation is denied
+test_empty_operation_request_denied {
+    results := violation with input as {
+        "parameters": {
+            "namespacePathWhitelist":
+                {
+                    "example-ns": [
+                        "/"
+                    ]
+                },
+            "host": "example.com"
+        },
+        "review": {
+            "operation": "",
+            "namespace": "example-ns",
+            "kind": {
+                "kind": "Ingress"
+            },
+            "object": {
+                "metadata": {
+                    "name": "test"
+                },
+                "spec": {
+                    "rules": [
+                        {
+                            "host": "example.com",
+                            "http": {
+                                "paths": [
+                                    {
+                                        "path": "/different"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    }
+    count(results) > 0
+}
+
+# test that a valid request with an empty operation is allowed
+test_empty_operation_request_allowed {
+    results := violation with input as {
+        "parameters": {
+            "namespacePathWhitelist":
+                {
+                    "example-ns": [
+                        "/"
+                    ]
+                },
+            "host": "example.com"
+        },
+        "review": {
+            "operation": "",
             "namespace": "example-ns",
             "kind": {
                 "kind": "Ingress"

--- a/base/library/ingress-host-restriction/template.yaml
+++ b/base/library/ingress-host-restriction/template.yaml
@@ -31,9 +31,8 @@ spec:
             # resource kind is Ingress
             input.review.kind.kind == "Ingress"
 
-            # operation is CREATE or UPDATE
-            operations = {"CREATE", "UPDATE"}
-            operations[input.review.operation]
+            # always allow deletion of offending ingresses
+            input.review.operation != "DELETE"
 
             # ingress host matches the restricted host
             host == input.parameters.host


### PR DESCRIPTION
The gatekeeper audit doesn't set an operation in the object that it passes to the policy. 