### PR TITLE
ingressrequirehost: use array comprehension

### DIFF
--- a/base/library/ingress-require-host/src.rego
+++ b/base/library/ingress-require-host/src.rego
@@ -8,7 +8,7 @@ violation[{"msg": msg}] {
   input.review.operation != "DELETE"
 
   # test if each rule has a host
-  hosts := {x | x = input.review.object.spec.rules[_].host}
+  hosts := [x | x := input.review.object.spec.rules[_].host]
   count(hosts) != count(input.review.object.spec.rules)
 
   msg := sprintf("Ingress '%v' denied; all rules must have a host defined", [input.review.object.metadata.name])

--- a/base/library/ingress-require-host/src_test.rego
+++ b/base/library/ingress-require-host/src_test.rego
@@ -17,7 +17,7 @@ test_pass {
               "host": "test.example.com"
             },
             {
-              "host": "test0.example.com",
+              "host": "test.example.com",
               "http": {
                 "paths": [
                   {

--- a/base/library/ingress-require-host/template.yaml
+++ b/base/library/ingress-require-host/template.yaml
@@ -26,7 +26,7 @@ spec:
           input.review.operation != "DELETE"
 
           # test if each rule has a host
-          hosts := {x | x = input.review.object.spec.rules[_].host}
+          hosts := [x | x := input.review.object.spec.rules[_].host]
           count(hosts) != count(input.review.object.spec.rules)
 
           msg := sprintf("Ingress '%v' denied; all rules must have a host defined", [input.review.object.metadata.name])


### PR DESCRIPTION
The previous comprehension would create a map, with the hosts as keys, meaning that duplicate host values would only be represented once in the count.