### PR TITLE
ingressroutematchrestriction: remove whitelist

### DIFF
--- a/base/library/ingressroute-match-restriction/src.rego
+++ b/base/library/ingressroute-match-restriction/src.rego
@@ -15,10 +15,6 @@ get_message(parameters, _default) = msg {
   msg := parameters.message
 }
 
-whitelisted(namespace) {
-  input.parameters.namespaceWhitelist[_] == namespace
-}
-
 # inverse = false
 violation[{"msg": msg}] {
   # only operate on supported kinds
@@ -33,9 +29,6 @@ violation[{"msg": msg}] {
   # match the regex to the route match field
   match := input.review.object.spec.routes[_].match
   re_match(match_regex, match)
-
-  # namespace isn't in the whitelist
-  not whitelisted(input.review.namespace)
 
   def_msg := sprintf("%s matches the restricted pattern: %s", [match, match_regex])
 
@@ -56,9 +49,6 @@ violation[{"msg": msg}] {
   # the route match field doesn't match the regex
   match := input.review.object.spec.routes[_].match
   not re_match(match_regex, match)
-
-  # namespace isn't in the whitelist
-  not whitelisted(input.review.namespace)
 
   def_msg := sprintf("%s doesn't match the required pattern: %s", [match, match_regex])
 

--- a/base/library/ingressroute-match-restriction/src_test.rego
+++ b/base/library/ingressroute-match-restriction/src_test.rego
@@ -34,62 +34,6 @@ test_ingressroute_inverse {
   count(results) == 4
 }
 
-# Test that a matching route doesn't produce a violation if it's whitelisted
-test_ingressroute_whitelist {
-  results := violation with input as {
-    "parameters": {
-      "matchRegex": "Host\\(.*(`|\")example.com(`|\").*\\)",
-      "namespaceWhitelist": ["kube-system", "example"],
-    },
-    "review": {
-      "namespace": "example",
-      "operation": "CREATE",
-      "kind": {"kind": "IngressRoute"},
-      "object": {
-        "metadata": {"name": "test"},
-        "spec": {"routes": [
-          {"match": "Host(`example.com`)"},
-          {"match": "Host(\"example.com\")"},
-          {"match": "Host(`example.com`, `not-example.com`)"},
-          {"match": "Host(\"not-example.com\", \"example.com\")"},
-          {"match": "Host(`not-example.com`)"},
-        ]},
-      },
-    },
-  }
-
-  count(results) == 0
-}
-
-# Test that a matching route produces a violation if it isn't in the whitelist
-test_ingressroute_whitelist_violation {
-  results := violation with input as {
-    "parameters": {
-      "matchRegex": "Host\\(.*(`|\")example.com(`|\").*\\)",
-      "namespaceWhitelist": ["kube-system", "example"],
-    },
-    "review": {
-      "namespace": "notwhitelisted",
-      "operation": "CREATE",
-      "kind": {"kind": "IngressRoute"},
-      "object": {
-        "metadata": {"name": "test"},
-        "spec": {"routes": [
-          {"match": "Host(`example.com`)"},
-          {"match": "Host(\"example.com\")"},
-          {"match": "Host(`example.com`, `not-example.com`)"},
-          {"match": "Host(\"not-example.com\", \"example.com\")"},
-          {"match": "Host(\"not-example.com\", \"example.com\") && PathPrefix(`/example`)"},
-          # shouldn't produce a violation
-          {"match": "Host(`not-example.com`)"},
-        ]},
-      },
-    },
-  }
-
-  count(results) == 5
-}
-
 # Test that a matching string produces a violation
 test_ingressroute {
   results := violation with input as {

--- a/base/library/ingressroute-match-restriction/template.yaml
+++ b/base/library/ingressroute-match-restriction/template.yaml
@@ -17,10 +17,6 @@ spec:
               type: string
             inverse:
               type: boolean
-            namespaceWhitelist:
-              type: array
-              items:
-                type: string
             message:
               type: string
   targets:
@@ -43,10 +39,6 @@ spec:
           msg := parameters.message
         }
 
-        whitelisted(namespace) {
-          input.parameters.namespaceWhitelist[_] == namespace
-        }
-
         # inverse = false
         violation[{"msg": msg}] {
           # only operate on supported kinds
@@ -61,9 +53,6 @@ spec:
           # match the regex to the route match field
           match := input.review.object.spec.routes[_].match
           re_match(match_regex, match)
-
-          # namespace isn't in the whitelist
-          not whitelisted(input.review.namespace)
 
           def_msg := sprintf("%s matches the restricted pattern: %s", [match, match_regex])
 
@@ -84,9 +73,6 @@ spec:
           # the route match field doesn't match the regex
           match := input.review.object.spec.routes[_].match
           not re_match(match_regex, match)
-
-          # namespace isn't in the whitelist
-          not whitelisted(input.review.namespace)
 
           def_msg := sprintf("%s doesn't match the required pattern: %s", [match, match_regex])
 


### PR DESCRIPTION
This can actually be achieved using the `excludedNamespaces` field on the constraint definition, so there's no need to put it in the code.