### PR TITLE
ingressroutematchrestriction: cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ kustomize:
 
 .PHONY: template
 template:
-	@docker run -ti --rm -v $$PWD:/workdir:ro mikefarah/yq /bin/sh -c " \
+	@docker run -i --rm -v $$PWD:/workdir:ro mikefarah/yq /bin/sh -c " \
 		apk --no-cache add bash && \
 		/workdir/lib/template-match-src/template-match-src"
 

--- a/base/library/ingressroute-match-restriction/README.md
+++ b/base/library/ingressroute-match-restriction/README.md
@@ -17,7 +17,6 @@ a regular expression match.
 - `inverse` - perform an inverse match. The default (`false`) will produce a
   violation for matching routes. Whereas, `true` will block routes that DON'T
   match the regular expression.
-- `namespaceWhitelist` - a list of namespaces that are exempt from the constraint.
 
 ## Examples
 
@@ -32,14 +31,13 @@ spec:
   match:
     kinds:
       - apiGroups: ["traefik.containo.us"]
-        kinds: ["IngressRoute"]
-  parameters:
-    message: |-
-      An IngressRoute matching example.com is not permitted in this namespace
-    matchRegex: "Host\\(.*(`|\")example.com(`|\").*\\)"
-    namespaceWhitelist:
+        kinds: ["IngressRoute", "IngressRouteTCP"]
+    excludedNamespaces:
       - kube-system
       - example-namespace
+  parameters:
+    message: "An IngressRoute or IngressRouteTCP matching example.com is not permitted in this namespace"
+    matchRegex: "Host(SNI)?\\([^\\)\\(]*`example.com`[^\\)\\(]*\\)"
 ```
 
 Use an inverse match to require a `Host()` value with valid FQDNs for
@@ -56,8 +54,8 @@ spec:
       - apiGroups: ["traefik.containo.us"]
         kinds: ["IngressRoute"]
   parameters:
-    message: "All route matches must contain a Host rule with a valid fqdn"
-    matchRegex: "Host\\(((`|\")([a-zA-Z0-9]{1,})(`|\")(,|, )?|(`|\")([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*\\.)+[a-z]{2,}(`|\")(,|, )?)+\\)"
+    message: "All route matches must contain a Host rule with valid hostnames as defined by RFC 1123"
+    matchRegex: "Host\\((`(([a-zA-Z0-9]{1,})|([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*\\.)+[a-z]{2,})`(, ?)?)+\\)"
     inverse: true
 ```
 
@@ -75,8 +73,7 @@ spec:
         kinds: ["IngressRoute", "IngressRouteTCP"]
   parameters:
     message: "Route matches must not contain ||"
-    matchRegex: "||"
-    namespaceWhitelist: ["kube-system"]
+    matchRegex: "\\|\\|"
 ```
 
 Prevent a wildcard match in `HostSNI` for `IngressRouteTCP` resources:
@@ -93,5 +90,5 @@ spec:
         kinds: ["IngressRouteTCP"]
   parameters:
     message: "HostSNI rules must not contain a wildcard host '*'"
-    matchRegex: "HostSNI\\(.*((`|\")(\\*)(`|\"))+.*\\)"
+    matchRegex: "HostSNI\\([^\\)\\(]*`\\*`[^\\)\\(]*\\)"
 ```


### PR DESCRIPTION
Some final housekeeping:
- Update the README with better, correct examples and remove references to `namespaceWhitelist`
- Update the tests so they reflect our use cases

Also, the template test isn't working for me in tmux. Removing the tty from the docker command fixes it and doesn't seem to affect circle or the tests outside of tmux.