### PR TITLE
Add annotationvalidation constrainttemplate

### DIFF
--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 bases:
   - github.com/open-policy-agent/gatekeeper/library/general/requiredlabels?ref=v3.1.0-beta.1
 resources:
+  - library/annotation-validation/template.yaml
   - library/delete-annotation-requirement/template.yaml
   - library/ingress-host-restriction/template.yaml
   - library/ingress-require-host/template.yaml

--- a/base/library/annotation-validation/src.rego
+++ b/base/library/annotation-validation/src.rego
@@ -1,0 +1,21 @@
+package annotationvalidation
+
+get_message(parameters, _default) = msg {
+  not parameters.message
+  msg := _default
+}
+
+get_message(parameters, _default) = msg {
+  msg := parameters.message
+}
+
+violation[{"msg": msg}] {
+  value := input.review.object.metadata.annotations[key]
+
+  expected := input.parameters.annotations[_]
+  expected.key == key
+  not re_match(expected.allowedRegex, value)
+
+  def_msg := sprintf("Annotation <%v: %v> does not satisfy allowed regex: %v", [key, value, expected.allowedRegex])
+  msg := get_message(input.parameters, def_msg)
+}

--- a/base/library/annotation-validation/src_test.rego
+++ b/base/library/annotation-validation/src_test.rego
@@ -1,0 +1,242 @@
+package annotationvalidation
+
+test_input_no_validation {
+  results := violation with input as {
+    "review": {"object": {"metadata": {
+      "name": "somename",
+      "annotations": {"some": "annotation"},
+    }}},
+    "parameters": {},
+  }
+
+  count(results) == 0
+}
+
+test_input_no_validation {
+  results := violation with input as {
+    "review": {"object": {"metadata": {"name": "somename"}}},
+    "parameters": {},
+  }
+
+  count(results) == 0
+}
+
+test_input_has_annotation {
+  results := violation with input as {
+    "review": {"object": {"metadata": {
+      "name": "somename",
+      "annotations": {"some": "annotation"},
+    }}},
+    "parameters": {"annotations": [{
+      "key": "some",
+      "allowedRegex": "annotation",
+    }]},
+  }
+
+  count(results) == 0
+}
+
+test_input_has_extra_annotation {
+  results := violation with input as {
+    "review": {"object": {"metadata": {
+      "name": "somename",
+      "annotations": {"some": "annotation", "new": "thing"},
+    }}},
+    "parameters": {"annotations": [{
+      "key": "some",
+      "allowedRegex": "annotation",
+    }]},
+  }
+
+  count(results) == 0
+}
+
+test_input_has_extra_annotation_req2 {
+  results := violation with input as {
+    "review": {"object": {"metadata": {
+      "name": "somename",
+      "annotations": {"some": "annotation", "new": "thing"},
+    }}},
+    "parameters": {"annotations": [
+      {
+        "key": "some",
+        "allowedRegex": "annotation",
+      },
+      {
+        "key": "new",
+        "allowedRegex": "thing",
+      },
+    ]},
+  }
+
+  count(results) == 0
+}
+
+test_input_missing_annotation {
+  results := violation with input as {
+    "review": {"object": {"metadata": {
+      "name": "somename",
+      "annotations": {"some_other": "annotation"},
+    }}},
+    "parameters": {"annotations": [{
+      "key": "some",
+      "allowedRegex": "annotation",
+    }]},
+  }
+
+  count(results) == 0
+}
+
+test_input_one_missing {
+  results := violation with input as {
+    "review": {"object": {"metadata": {
+      "name": "somename",
+      "annotations": {"some": "annotation"},
+    }}},
+    "parameters": {"annotations": [
+      {
+        "key": "some",
+        "allowedRegex": "annotation",
+      },
+      {
+        "key": "new",
+        "allowedRegex": "thing",
+      },
+    ]},
+  }
+
+  count(results) == 0
+}
+
+test_input_empty {
+  results := violation with input as {
+    "review": {"object": {"metadata": {"name": "somename"}}},
+    "parameters": {"annotations": [{
+      "key": "some",
+      "allowedRegex": "annotation$",
+    }]},
+  }
+
+  count(results) == 0
+}
+
+test_input_two_allowed {
+  results := violation with input as {
+    "review": {"object": {"metadata": {
+      "name": "somename",
+      "annotations": {"some": "grey", "other": "gray"},
+    }}},
+    "parameters": {"annotations": [
+      {
+        "key": "some",
+        "allowedRegex": "gr[ae]y",
+      },
+      {
+        "key": "other",
+        "allowedRegex": "gr[ae]y",
+      },
+    ]},
+  }
+
+  count(results) == 0
+}
+
+test_input_wrong_value {
+  results := violation with input as {
+    "review": {"object": {"metadata": {
+      "name": "somename",
+      "annotations": {"some": "annotation2"},
+    }}},
+    "parameters": {"annotations": [{
+      "key": "some",
+      "allowedRegex": "annotation$",
+    }]},
+  }
+
+  count(results) == 1
+}
+
+test_input_wrong_value_extra_annotation {
+  results := violation with input as {
+    "review": {"object": {"metadata": {
+      "name": "somename",
+      "annotations": {"some": "annotation2", "some_other": "annotation"},
+    }}},
+    "parameters": {"annotations": [{
+      "key": "some",
+      "allowedRegex": "annotation$",
+    }]},
+  }
+
+  count(results) == 1
+}
+
+test_input_two_wrong {
+  results := violation with input as {
+    "review": {"object": {"metadata": {
+      "name": "somename",
+      "annotations": {"some": "greyish", "other": "grayish"},
+    }}},
+    "parameters": {"annotations": [
+      {
+        "key": "some",
+        "allowedRegex": "gr[ae]y$",
+      },
+      {
+        "key": "other",
+        "allowedRegex": "gr[ae]y$",
+      },
+    ]},
+  }
+
+  count(results) == 2
+}
+
+test_input_message {
+  results := violation with input as {
+    "review": {"object": {"metadata": {
+      "name": "somename",
+      "annotations": {"some": "annotation2"},
+    }}},
+    "parameters": {
+      "message": "WRONG_VALUE",
+      "annotations": [{
+        "key": "some",
+        "allowedRegex": "annotation$",
+      }],
+    },
+  }
+
+  results[_].msg == "WRONG_VALUE"
+}
+
+# test a relatively complicated regex: matching an AWS role arn
+test_input_arn_pattern {
+  results := violation with input as {
+    "review": {"object": {"metadata": {
+      "name": "somename",
+      "annotations": {"arn": "arn:aws:iam::123456789012:role/aws-service-role/lex.amazonaws.com/AWSServiceRoleForLexBots"},
+    }}},
+    "parameters": {"annotations": [{
+      "key": "arn",
+      "allowedRegex": "^arn:aws:iam::[0-9]+:role((/)|(/[\\x21-\\x7f]+/))[\\w+=,.@-]+$",
+    }]},
+  }
+
+  count(results) == 0
+}
+
+test_input_arn_pattern_invalid {
+  results := violation with input as {
+    "review": {"object": {"metadata": {
+      "name": "somename",
+      "annotations": {"arn": "arn:aws:iam:123456789012:role/aws-service-role/lex.amazonaws.com/AWSServiceRoleForLexBots"},
+    }}},
+    "parameters": {"annotations": [{
+      "key": "arn",
+      "allowedRegex": "^arn:aws:iam::[0-9]+:role((/)|(/[\\x21-\\x7f]+/))[\\w+=,.@-]+$",
+    }]},
+  }
+
+  count(results) == 1
+}

--- a/base/library/annotation-validation/template.yaml
+++ b/base/library/annotation-validation/template.yaml
@@ -1,0 +1,49 @@
+# annotationvalidation validates the content of an annotation against a regex,
+# provided it exists
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: annotationvalidation
+spec:
+  crd:
+    spec:
+      names:
+        kind: AnnotationValidation
+      validation:
+        openAPIV3Schema:
+          properties:
+            message:
+              type: string
+            annotations:
+              type: array
+              items:
+                type: object
+                properties:
+                  key:
+                    type: string
+                  allowedRegex:
+                    type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package annotationvalidation
+
+        get_message(parameters, _default) = msg {
+          not parameters.message
+          msg := _default
+        }
+
+        get_message(parameters, _default) = msg {
+          msg := parameters.message
+        }
+
+        violation[{"msg": msg}] {
+          value := input.review.object.metadata.annotations[key]
+
+          expected := input.parameters.annotations[_]
+          expected.key == key
+          not re_match(expected.allowedRegex, value)
+
+          def_msg := sprintf("Annotation <%v: %v> does not satisfy allowed regex: %v", [key, value, expected.allowedRegex])
+          msg := get_message(input.parameters, def_msg)
+        }


### PR DESCRIPTION
This validates that the value of an annotation matches a given regex.

It's similar to k8srequiredlabels, except that it only applies when the annotation exists. It ignores objects where the annotation isn't set at all.