### PR TITLE
Fix delete-annotation-requirement

### DIFF
--- a/base/library/delete-annotation-requirement/src.rego
+++ b/base/library/delete-annotation-requirement/src.rego
@@ -1,16 +1,14 @@
 package deleteannotationrequirement
 
 violation[{"msg": msg, "details": {
-    "name": name,
-    "kind": kind,
-    "namespace": namespace
+  "name": name,
+  "kind": kind,
 }}] {
-    name := input.review.object.metadata.name
-    kind := input.review.kind.kind
-    namespace := input.review.namespace
+  name := input.review.object.metadata.name
+  kind := input.review.kind.kind
 
-    input.review.operation == "DELETE"
-    not input.review.object.metadata.annotations[input.parameters.name] == input.parameters.value
+  input.review.operation == "DELETE"
+  not input.review.object.metadata.annotations[input.parameters.name] == input.parameters.value
 
-    msg := sprintf("the %v '%v' must be annotated with '%v: \"%v\"' to be deleted", [kind, name, input.parameters.name, input.parameters.value])
+  msg := sprintf("the %v '%v' must be annotated with '%v: \"%v\"' to be deleted", [kind, name, input.parameters.name, input.parameters.value])
 }

--- a/base/library/delete-annotation-requirement/src_test.rego
+++ b/base/library/delete-annotation-requirement/src_test.rego
@@ -2,125 +2,69 @@ package deleteannotationrequirement
 
 # test that an object annotated with "true" is allowed
 test_annotated_allowed {
-    not violation[{
-        "msg": "",
-        "details": {
-            "name": "example-ns",
-            "kind": "Namespace",
-            "namespace": "example-ns"
-        }
-    }] with input as {
-        "review": {
-            "namespace": "example-ns",
-            "kind": {
-                "kind": "Namespace"
-            },
-            "object": {
-                "metadata": {
-                    "name": "example-ns",
-                    "annotations": {
-                        "example.com/delete-allowed": "true"
-                    }
-                }
-            },
-            "operation": "DELETE"
-        },
-        "parameters": {
-            "name": "example.com/delete-allowed",
-            "value": "true",
-        }
-    }
+  not violation[{"msg": "", "details": {"name": "example-ns", "kind": "Namespace"}}] with input as {
+    "review": {
+      "kind": {"kind": "Namespace"},
+      "object": {"metadata": {
+        "name": "example-ns",
+        "annotations": {"example.com/delete-allowed": "true"},
+      }},
+      "operation": "DELETE",
+    },
+    "parameters": {
+      "name": "example.com/delete-allowed",
+      "value": "true",
+    },
+  }
 }
 
 # test that an object annotated with "false" is denied
 test_annotated_denied {
-    violation[{
-        "msg": "the Namespace 'example-ns' must be annotated with 'example.com/delete-allowed: \"true\"' to be deleted",
-        "details": {
-            "name": "example-ns",
-            "kind": "Namespace",
-            "namespace": "example-ns"
-        }
-    }] with input as {
-        "review": {
-            "namespace": "example-ns",
-            "kind": {
-                "kind": "Namespace"
-            },
-            "object": {
-                "metadata": {
-                    "name": "example-ns",
-                    "annotations": {
-                        "example.com/delete-allowed": "false"
-                    }
-                }
-            },
-            "operation": "DELETE"
-        },
-        "parameters": {
-            "name": "example.com/delete-allowed",
-            "value": "true"
-        }
-    }
+  violation[{"msg": "the Namespace 'example-ns' must be annotated with 'example.com/delete-allowed: \"true\"' to be deleted", "details": {"name": "example-ns", "kind": "Namespace"}}] with input as {
+    "review": {
+      "kind": {"kind": "Namespace"},
+      "object": {"metadata": {
+        "name": "example-ns",
+        "annotations": {"example.com/delete-allowed": "false"},
+      }},
+      "operation": "DELETE",
+    },
+    "parameters": {
+      "name": "example.com/delete-allowed",
+      "value": "true",
+    },
+  }
 }
 
 # test that an object without any annotation at all is denied
 test_not_annotated_denied {
-    violation[{
-        "msg": "the Namespace 'example-ns' must be annotated with 'example.com/delete-allowed: \"true\"' to be deleted",
-        "details": {
-            "name": "example-ns",
-            "kind": "Namespace",
-            "namespace": "example-ns"
-        }
-    }] with input as {
-        "review": {
-            "namespace": "example-ns",
-            "kind": {
-                "kind": "Namespace"
-            },
-            "object": {
-                "metadata": {
-                    "name": "example-ns"
-                }
-            },
-            "operation": "DELETE"
-        },
-        "parameters": {
-            "name": "example.com/delete-allowed",
-            "value": "true",
-        }
-    }
+  violation[{"msg": "the Namespace 'example-ns' must be annotated with 'example.com/delete-allowed: \"true\"' to be deleted", "details": {"name": "example-ns", "kind": "Namespace"}}] with input as {
+    "review": {
+      "kind": {"kind": "Namespace"},
+      "object": {"metadata": {"name": "example-ns"}},
+      "operation": "DELETE",
+    },
+    "parameters": {
+      "name": "example.com/delete-allowed",
+      "value": "true",
+    },
+  }
 }
 
 # test that the policy only applies to delete operations
 test_create_allowed {
-    not violation[{
-        "msg": "",
-        "details": {
-            "name": "example-ns",
-            "kind": "Namespace",
-            "namespace": "example-ns"
-        }
-    }] with input as {
-        "review": {
-            "namespace": "example-ns",
-            "kind": {
-                "kind": "Namespace"
-            },
-            "object": {
-                "metadata": {
-                    "name": "example-ns",
-                    "annotations": {
-                        "example.com/delete-allowed": "false"
-                    }
-                }
-            },
-            "operation": "CREATE"
-        },
-        "parameters": {
-            "name": "example.com/delete-allowed",
-            "value": "true",
-        }
-    }
+  not violation[{"msg": "", "details": {"name": "example-ns", "kind": "Namespace"}}] with input as {
+    "review": {
+      "kind": {"kind": "Namespace"},
+      "object": {"metadata": {
+        "name": "example-ns",
+        "annotations": {"example.com/delete-allowed": "false"},
+      }},
+      "operation": "CREATE",
+    },
+    "parameters": {
+      "name": "example.com/delete-allowed",
+      "value": "true",
+    },
+  }
 }

--- a/base/library/delete-annotation-requirement/template.yaml
+++ b/base/library/delete-annotation-requirement/template.yaml
@@ -22,16 +22,14 @@ spec:
         package deleteannotationrequirement
 
         violation[{"msg": msg, "details": {
-            "name": name,
-            "kind": kind,
-            "namespace": namespace
+          "name": name,
+          "kind": kind,
         }}] {
-            name := input.review.object.metadata.name
-            kind := input.review.kind.kind
-            namespace := input.review.namespace
+          name := input.review.object.metadata.name
+          kind := input.review.kind.kind
 
-            input.review.operation == "DELETE"
-            not input.review.object.metadata.annotations[input.parameters.name] == input.parameters.value
+          input.review.operation == "DELETE"
+          not input.review.object.metadata.annotations[input.parameters.name] == input.parameters.value
 
-            msg := sprintf("the %v '%v' must be annotated with '%v: \"%v\"' to be deleted", [kind, name, input.parameters.name, input.parameters.value])
+          msg := sprintf("the %v '%v' must be annotated with '%v: \"%v\"' to be deleted", [kind, name, input.parameters.name, input.parameters.value])
         }


### PR DESCRIPTION
It looks like Kubernetes or Gatekeeper have stopped populating the `input.review.namespace` field for actual `Namespaces`. Previously, this would hold the name of the Namespace.

The namespace is only used informationally, so it's fine to just remove it.