### PR TITLE
ingressroute-match-restriction: add exceptions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ kustomize:
 
 .PHONY: template
 template:
-	@docker run -i --rm -v $$PWD:/workdir:ro mikefarah/yq /bin/sh -c " \
+	@docker run -i --rm -v $$PWD:/workdir:ro --entrypoint sh mikefarah/yq:4 -c " \
 		apk --no-cache add bash && \
 		/workdir/lib/template-match-src/template-match-src"
 

--- a/base/library/ingressroute-match-restriction/src.rego
+++ b/base/library/ingressroute-match-restriction/src.rego
@@ -15,6 +15,15 @@ get_message(parameters, _default) = msg {
   msg := parameters.message
 }
 
+excepted(match) {
+  exceptions := input.parameters.exceptions
+
+  input.review.object.metadata.name == exceptions[i].name
+  input.review.namespace == exceptions[i].namespace
+  input.review.kind.kind == exceptions[i].kind
+  match == exceptions[i].match
+}
+
 # inverse = false
 violation[{"msg": msg}] {
   # only operate on supported kinds
@@ -29,6 +38,10 @@ violation[{"msg": msg}] {
   # match the regex to the route match field
   match := input.review.object.spec.routes[_].match
   re_match(match_regex, match)
+
+  # if there's an exception for this match then it shouldn't produce a
+  # violation
+  not excepted(match)
 
   def_msg := sprintf("%s matches the restricted pattern: %s", [match, match_regex])
 
@@ -49,6 +62,10 @@ violation[{"msg": msg}] {
   # the route match field doesn't match the regex
   match := input.review.object.spec.routes[_].match
   not re_match(match_regex, match)
+
+  # if there's an exception for this match then it shouldn't produce a
+  # violation
+  not excepted(match)
 
   def_msg := sprintf("%s doesn't match the required pattern: %s", [match, match_regex])
 

--- a/base/library/ingressroute-match-restriction/template.yaml
+++ b/base/library/ingressroute-match-restriction/template.yaml
@@ -19,6 +19,19 @@ spec:
               type: boolean
             message:
               type: string
+            exceptions:
+              type: array
+              items:
+                type: object
+                properties:
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                  match:
+                    type: string
   targets:
     - target: admission.k8s.gatekeeper.sh
       rego: |
@@ -39,6 +52,15 @@ spec:
           msg := parameters.message
         }
 
+        excepted(match) {
+          exceptions := input.parameters.exceptions
+
+          input.review.object.metadata.name == exceptions[i].name
+          input.review.namespace == exceptions[i].namespace
+          input.review.kind.kind == exceptions[i].kind
+          match == exceptions[i].match
+        }
+
         # inverse = false
         violation[{"msg": msg}] {
           # only operate on supported kinds
@@ -53,6 +75,10 @@ spec:
           # match the regex to the route match field
           match := input.review.object.spec.routes[_].match
           re_match(match_regex, match)
+
+          # if there's an exception for this match then it shouldn't produce a
+          # violation
+          not excepted(match)
 
           def_msg := sprintf("%s matches the restricted pattern: %s", [match, match_regex])
 
@@ -73,6 +99,10 @@ spec:
           # the route match field doesn't match the regex
           match := input.review.object.spec.routes[_].match
           not re_match(match_regex, match)
+
+          # if there's an exception for this match then it shouldn't produce a
+          # violation
+          not excepted(match)
 
           def_msg := sprintf("%s doesn't match the required pattern: %s", [match, match_regex])
 

--- a/lib/template-match-src/template-match-src
+++ b/lib/template-match-src/template-match-src
@@ -5,13 +5,13 @@
 
 code=0
 
-rego_field="spec.targets[0].rego"
+rego_field=".spec.targets[0].rego"
 
 while read template_file; do
 	IFS=
 	src_file=$(dirname ${template_file})/src.rego
 
-	DIFF=$(diff -B <(cat ${src_file})  <(yq r "${template_file}" "${rego_field}"))
+	DIFF=$(diff -B <(cat ${src_file})  <(yq eval "${rego_field}" "${template_file}"))
 
 	if [[ ${DIFF} != "" ]]; then
 		echo -e "${template_file}: the contents of ${rego_field} don't match ${src_file}:\n\n${DIFF}"


### PR DESCRIPTION
Introduce the ability to except specific matches on `IngressRoute` or `IngressRouteTCP` resources from the constraint:
```
exceptions:
  - kind: IngressRoute
    name: example
    namespace: kube-system
    match: HostRegexp(`{subdomain:[a-f0-9]{7}}.example.com`)
```

The match is the literal string that is permitted as a match in the `.spec.routes[].match` field.

Also update `yq` to v4 in the tests.