### PR TITLE
taint-tolerations: remove unsupported name fields

### DIFF
--- a/base/library/taint-tolerations/template.yaml
+++ b/base/library/taint-tolerations/template.yaml
@@ -7,9 +7,6 @@ spec:
     spec:
       names:
         kind: RestrictedTaintToleration
-        listKind: RestrictedTaintToleration
-        plural: restrictedtainttolerations
-        singular: restrictedtainttoleration
       validation:
         openAPIV3Schema:
           properties:


### PR DESCRIPTION
These were never actually supported by the CRD and the new v1 version now out and out fails validation if they're present.