### PR TITLE
Add podnoderestriction

### DIFF
--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -11,4 +11,5 @@ resources:
   - library/ingress-require-host/template.yaml
   - library/ingressroute-match-restriction/template.yaml
   - library/name-label-match/template.yaml
+  - library/pod-node-restriction/template.yaml
   - library/taint-tolerations/template.yaml

--- a/base/library/pod-node-restriction/src.rego
+++ b/base/library/pod-node-restriction/src.rego
@@ -1,0 +1,31 @@
+package podnoderestriction
+
+get_message(node_name) = msg {
+  not input.parameters.message
+  msg := sprintf("not permitted to be scheduled on node: %s", [node_name])
+}
+
+get_message(node_name) = msg {
+  msg := input.parameters.message
+}
+
+# always match if matchLabels is nil
+match_labels(labels) {
+  not input.parameters.matchLabels
+}
+
+# ensure that every key=value pair in matchLabels is in labels
+match_labels(labels) {
+  count(input.parameters.matchLabels) == count({label_value | label_value := input.parameters.matchLabels[label_key]; labels[label_key] == label_value})
+}
+
+violation[{"msg": msg}] {
+  input.review.operation != "DELETE"
+
+  node_name := input.review.object.spec.nodeName
+  node := data.inventory.cluster.v1.Node[node_name]
+
+  match_labels(node.metadata.labels)
+
+  msg := get_message(node_name)
+}

--- a/base/library/pod-node-restriction/src_test.rego
+++ b/base/library/pod-node-restriction/src_test.rego
@@ -1,0 +1,115 @@
+package podnoderestriction
+
+# test that a matching node causes a violation
+test_blocked {
+  results := violation with input as {
+    "parameters": {"matchLabels": {"foo": "bar", "baz": ""}},
+    "review": {"operation": "CREATE", "object": {
+      "metadata": {"name": "example-ns"},
+      "spec": {"nodeName": "foobar"},
+    }},
+  }
+     with data.inventory as {"cluster": {"v1": {"Node": {"foobar": {"metadata": {"labels": {
+      "foo": "bar",
+      "baz": "",
+      "bar": "foo",
+    }}}}}}}
+
+  count(results) == 1
+}
+
+# test that when no matchLabels are defined, that the node is still blocked
+# (no matchLabels == match all)
+test_no_matchLabels_blocked {
+  results := violation with input as {"review": {"operation": "CREATE", "object": {
+    "metadata": {"name": "example-ns"},
+    "spec": {"nodeName": "foobar"},
+  }}}
+     with data.inventory as {"cluster": {"v1": {"Node": {"foobar": {"metadata": {"labels": {
+      "foo": "bar",
+      "baz": "",
+      "bar": "foo",
+    }}}}}}}
+
+  count(results) == 1
+}
+
+test_message {
+  results := violation with input as {
+    "parameters": {"message": "TEST_MESSAGE", "matchLabels": {"foo": "bar"}},
+    "review": {"operation": "CREATE", "object": {
+      "metadata": {"name": "example-ns"},
+      "spec": {"nodeName": "foobar"},
+    }},
+  }
+     with data.inventory as {"cluster": {"v1": {"Node": {"foobar": {"metadata": {"labels": {"foo": "bar"}}}}}}}
+
+  count(results) == 1
+  results[_].msg == "TEST_MESSAGE"
+}
+
+# test that the node isn't matched if it  doesn't contain one of the
+# matchLabels
+test_missing_label_allowed {
+  results := violation with input as {
+    "parameters": {"matchLabels": {"foo": "bar", "baz": ""}},
+    "review": {"operation": "CREATE", "object": {
+      "metadata": {"name": "example-ns"},
+      "spec": {"nodeName": "foobar"},
+    }},
+  }
+     with data.inventory as {"cluster": {"v1": {"Node": {"foobar": {"metadata": {"labels": {
+      "foo": "bar",
+      "bar": "foo",
+    }}}}}}}
+
+  count(results) == 0
+}
+
+# test that there's no violation when the node isn't in the inventory
+test_missing_node_allowed {
+  results := violation with input as {
+    "parameters": {"matchLabels": {"foo": "bar", "baz": ""}},
+    "review": {"operation": "CREATE", "object": {
+      "metadata": {"name": "example-ns"},
+      "spec": {"nodeName": "foobar"},
+    }},
+  }
+     with data.inventory as {"cluster": {"v1": {"Node": {"not-foobar": {"metadata": {"labels": {
+      "foo": "bar",
+      "bar": "foo",
+    }}}}}}}
+
+  count(results) == 0
+}
+
+# test that there's no violation when the inventory is nil
+test_no_inventory_allowed {
+  results := violation with input as {
+    "parameters": {"matchLabels": {"foo": "bar", "baz": ""}},
+    "review": {"operation": "CREATE", "object": {
+      "metadata": {"name": "example-ns"},
+      "spec": {"nodeName": "foobar"},
+    }},
+  }
+
+  count(results) == 0
+}
+
+# test that a pod can be deleted even if it's scheduled to a matching node 
+test_blocked {
+  results := violation with input as {
+    "parameters": {"matchLabels": {"foo": "bar", "baz": ""}},
+    "review": {"operation": "DELETE", "object": {
+      "metadata": {"name": "example-ns"},
+      "spec": {"nodeName": "foobar"},
+    }},
+  }
+     with data.inventory as {"cluster": {"v1": {"Node": {"foobar": {"metadata": {"labels": {
+      "foo": "bar",
+      "baz": "",
+      "bar": "foo",
+    }}}}}}}
+
+  count(results) == 0
+}

--- a/base/library/pod-node-restriction/template.yaml
+++ b/base/library/pod-node-restriction/template.yaml
@@ -1,0 +1,53 @@
+# prevents scheduling to nodes that match the given matchLabels selector
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: podnoderestriction
+spec:
+  crd:
+    spec:
+      names:
+        kind: PodNodeRestriction
+      validation:
+        openAPIV3Schema:
+          properties:
+            message:
+              type: string
+            matchLabels:
+              type: object
+              additionalProperties:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package podnoderestriction
+
+        get_message(node_name) = msg {
+          not input.parameters.message
+          msg := sprintf("not permitted to be scheduled on node: %s", [node_name])
+        }
+
+        get_message(node_name) = msg {
+          msg := input.parameters.message
+        }
+
+        # always match if matchLabels is nil
+        match_labels(labels) {
+          not input.parameters.matchLabels
+        }
+
+        # ensure that every key=value pair in matchLabels is in labels
+        match_labels(labels) {
+          count(input.parameters.matchLabels) == count({label_value | label_value := input.parameters.matchLabels[label_key]; labels[label_key] == label_value})
+        }
+
+        violation[{"msg": msg}] {
+          input.review.operation != "DELETE"
+
+          node_name := input.review.object.spec.nodeName
+          node := data.inventory.cluster.v1.Node[node_name]
+
+          match_labels(node.metadata.labels)
+
+          msg := get_message(node_name)
+        }


### PR DESCRIPTION
Allows you to block pods from being scheduled onto nodes that match a particular set of labels.

The taints/tolerations system will prevent the scheduler from assigning pods to particular nodes but it will not prevent someone from explicitly assigning their pod to a node with the `nodeName` field.

This constraint allows you to patch that hole.

Example:
```
apiVersion: constraints.gatekeeper.sh/v1beta1
kind: PodNodeRestriction
metadata:
  name: "master"
spec:
  match:
    kinds:
      - apiGroups: [""]
        kinds: ["Pod"]
    excludedNamespaces:
      - kube-system
  parameters:
    message: "Pod is not allowed to be scheduled onto master nodes"
    matchLabels:
      node-role.kubernetes.io/master: ""
```
