### PR TITLE
Prototype for PodSecurityPolice replacement

### DIFF
--- a/base/library/hardenedpodvalidation/src.rego
+++ b/base/library/hardenedpodvalidation/src.rego
@@ -1,0 +1,28 @@
+package hardenedpodvalidation
+
+containers[c] {
+  c := input.review.object.spec.containers[_]
+}
+
+containers[c] {
+  c := input.review.object.spec.initContainers[_]
+}
+
+containers[c] {
+  c := input.review.object.spec.ephemeralContainers[_]
+}
+
+violation [{"msg":msg}] {
+  c := containers[_]
+  c.securityContext.privileged == true
+  msg := sprintf("Privileged container is not allowed: %v", [c.name])
+}
+
+violation[{"msg": msg}] {
+  c := containers[_]
+  # convert the arrays into sets, so we can substract them
+  capabilities := { x | x := c.securityContext.capabilities.add[_] }
+  allowedCapabilities := { y | y:= input.parameters.allowedCapabilities[_] }
+  count(capabilities - allowedCapabilities) > 0
+  msg := sprintf("Container has disallowed capabilities: %v", [c.name])
+}

--- a/base/library/hardenedpodvalidation/src_test.rego
+++ b/base/library/hardenedpodvalidation/src_test.rego
@@ -1,0 +1,104 @@
+package hardenedpodvalidation
+
+test_allow_unprivileged {
+  results := violation with input as {
+    "review": {"operation": "CREATE", "object": {
+      "spec": {"containers":[
+        {"name":"example1","securityContext": {}}
+      ]}
+    }}
+  }
+  count(results) == 0
+}
+
+test_disallow_privileged_containers {
+  results := violation with input as {
+    "review": {"operation": "CREATE", "object": {
+      "spec": {"containers":[
+        {"name":"example1","securityContext": {"privileged":true}}
+      ]}
+    }}
+  }
+  count(results) == 1
+}
+
+test_disallow_privileged_initContainers {
+  results := violation with input as {
+    "review": {"operation": "CREATE", "object": {
+      "spec": {"initContainers":[
+        {"name":"example1","securityContext": {"privileged":true}}
+      ]}
+    }}
+  }
+  count(results) == 1
+}
+
+test_disallow_privileged_ephemeralContainers {
+  results := violation with input as {
+    "review": {"operation": "CREATE", "object": {
+      "spec": {"ephemeralContainers":[
+        {"name":"example1","securityContext": {"privileged":true}}
+      ]}
+    }}
+  }
+  count(results) == 1
+}
+
+test_allow_no_capabilities {
+  results := violation with input as {
+    "review": {"operation": "CREATE", "object": {
+      "spec": {"containers":[
+      	{"name":"example1","securityContext": {"capabilities": {"add": []}}}
+      ]}
+    }}
+  }
+  count(results) == 0
+}
+
+test_allow_allowed_capabilities {
+  results := violation with input as {
+    "parameters": {"allowedCapabilities": ["alpha"]},
+    "review": {"operation": "CREATE", "object": {
+      "spec": {"containers":[
+      	{"name":"example1","securityContext": {"capabilities": {"add": ["alpha"]}}}
+      ]}
+    }}
+  }
+  count(results) == 0
+}
+
+test_allow_allowed_capabilities_2 {
+  results := violation with input as {
+    "parameters": {"allowedCapabilities": ["alpha","beta"]},
+    "review": {"operation": "CREATE", "object": {
+      "spec": {"containers":[
+      	{"name":"example1","securityContext": {"capabilities": {"add": ["beta"]}}}
+      ]}
+    }}
+  }
+  count(results) == 0
+}
+
+test_disallow_unallowed_capabilities {
+  results := violation with input as {
+    "parameters": {"allowedCapabilities": []},
+    "review": {"operation": "CREATE", "object": {
+      "spec": {"containers":[
+      	{"name":"example1","securityContext": {"capabilities": {"add": ["something"]}}}
+      ]}
+    }}
+  }
+  count(results) == 1
+}
+
+test_disallow_unallowed_capabilities_2 {
+  results := violation with input as {
+    "parameters": {"allowedCapabilities": ["alpha"]},
+    "review": {"operation": "CREATE", "object": {
+      "spec": {"containers":[
+      	{"name":"example1","securityContext": {"capabilities": {"add": ["alpha","beta"]}}}
+      ]}
+    }}
+  }
+  count(results) == 1
+}

--- a/base/library/hardenedpodvalidation/template.yaml
+++ b/base/library/hardenedpodvalidation/template.yaml
@@ -1,0 +1,49 @@
+# prevents scheduling pods without hardened values
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: hardenedpodvalidation
+spec:
+  crd:
+    spec:
+      names:
+        kind: hardenedpodvalidation
+      validation:
+        openAPIV3Schema:
+          properties:
+            allowedCapabilities:
+              type: object
+              additionalProperties:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package hardenedpodvalidation
+        
+        containers[c] {
+          c := input.review.object.spec.containers[_]
+        }
+        
+        containers[c] {
+          c := input.review.object.spec.initContainers[_]
+        }
+        
+        containers[c] {
+          c := input.review.object.spec.ephemeralContainers[_]
+        }
+        
+        violation [{"msg":msg}] {
+          c := containers[_]
+          c.securityContext.privileged == true
+          msg := sprintf("Privileged container is not allowed: %v", [c.name])
+        }
+        
+        violation[{"msg": msg}] {
+          c := containers[_]
+          # convert the arrays into sets, so we can substract them
+          capabilities := { x | x := c.securityContext.capabilities.add[_] }
+          allowedCapabilities := { y | y:= input.parameters.allowedCapabilities[_] }
+          count(capabilities - allowedCapabilities) > 0
+          msg := sprintf("Container has disallowed capabilities: %v", [c.name])
+        }
+


### PR DESCRIPTION
Subset of the required validations

The idea is to have a constrain of this template for a set of namespaces, acting as a "boundary", defining the most permissive pod that a namespace can run